### PR TITLE
Allow plandoing password

### DIFF
--- a/Spoiler.py
+++ b/Spoiler.py
@@ -85,9 +85,10 @@ class Spoiler:
             self.file_hash.append(random.randint(0, 31) if dist_file_hash[i] is None else HASH_ICONS.index(dist_file_hash[i]))
 
     def build_password(self, password: bool = False) -> None:
+        dist_password = self.settings.distribution.password
         for i in range(6):
             if password:
-                self.password.append(random.randint(1, 5))
+                self.password.append(random.randint(1, 5) if dist_password[i] is None else PASSWORD_NOTES.index(dist_password[i]) + 1)
             else:
                 self.password.append(0)
 


### PR DESCRIPTION
Makes it so the `password` entry in a plando is no longer ignored.